### PR TITLE
Add epimodel-covid-data as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 .idea
 /*.egg-info
 .ipynb_checkpoints
-/data
 /epimodel/data
 /out
 config-local.yaml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "data"]
+	path = data
+	url = git@github.com:epidemics/epimodel-covid-data.git

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ print(csse.loc[('CZ', "2020-03-28")])
 Assuming you've installed deps via `poetry install` and you are in the root epimodel repo.
 Also, you did `cp config.yaml config-local.yaml` (modifying it as fit) and set e.g. `export_regions: [CZ, ES]`. Prepend `-C config-local.yaml` to all commands below to use it rather than `config.yaml`.
 
-1. Clone data repo or update it.
-   `git clone https://github.com/epidemics/epimodel-covid-data data`
+1. If you haven't cloned this repo with `--recurse-submodules`, pull them now via:
+   `git pull --recurse-submodules`
 
 2. Optional: Update Johns Hopkins data `./do -C config-local.yaml update_john_hopkins` (not needed if you got fresh data from the repo above).
 


### PR DESCRIPTION
We have a heavy dependency on the data module, i.e. this repository main entrypoints/commands are not usable without having the right version of https://github.com/epidemics/epimodel-covid-data (as has been shown in the last few days). 

I propose we put data as it's own submodule and therefore have guarantee that we can run the master branch as is and also develop stuff independently depending on what branch from this repo need a branch from other one.