### PR TITLE
Update gleam import and web export to support cities

### DIFF
--- a/epimodel/exports/epidemics_org.py
+++ b/epimodel/exports/epidemics_org.py
@@ -387,6 +387,8 @@ def get_df_else_none(df: pd.DataFrame, code) -> Optional[pd.DataFrame]:
 
 
 def get_df_list(df: pd.DataFrame, code) -> pd.DataFrame:
+    if code not in df.index:
+        return df.loc[[]]
     return df.loc[[code]].sort_index()
 
 
@@ -441,7 +443,7 @@ def process_export(args) -> None:
     models_df_old: pd.DataFrame = batch.hdf["new_fraction"]
     cummulative_active_df = batch.get_cummulative_active_df()
 
-    estimates_df = epimodel.read_csv_smart(args.estimates, args.rds)
+    estimates_df = epimodel.read_csv_smart(args.estimates, args.rds, prefer_higher=True)
 
     rates_df: pd.DataFrame = pd.read_csv(
         rates, index_col="Code", keep_default_na=False, na_values=[""]
@@ -484,7 +486,7 @@ def process_export(args) -> None:
 
     for code in export_regions:
         reg: Region = args.rds[code]
-        m49 = int(reg["M49Code"])
+        m49 = int(reg["M49Code"]) if pd.notnull(reg["M49Code"]) else -1
         iso3 = reg["CountryCodeISOa3"]
 
         ex.new_region(

--- a/epimodel/gleam/batch.py
+++ b/epimodel/gleam/batch.py
@@ -21,7 +21,7 @@ SIMULATION_COLUMNS = ["Name", "Group", "Key", "StartDate", "DefinitionXML"]
 LEVEL_TO_GTYPE = {
     Level.country: "country",
     Level.continent: "continent",
-    Level.gleam_basin: "city",
+    Level.gleam_basin: "basin",
 }
 COMPARTMENTS = {2: "Infected", 3: "Recovered"}
 

--- a/epimodel/regions.py
+++ b/epimodel/regions.py
@@ -78,7 +78,10 @@ class Region:
         return self.Name
 
     def __getattr__(self, name):
-        return self.__getitem__(name)
+        if name.startswith("_"):
+            return super().__getattr__(name)
+        else:
+            return self.__getitem__(name)
 
     def __getitem__(self, name):
         return self._rds().data.at[self._code, name]

--- a/epimodel/regions.py
+++ b/epimodel/regions.py
@@ -59,12 +59,22 @@ class Region:
         rds.data.at[code, "AllNames"] = list(set(names))
         rds.data.at[code, "Region"] = self
         rds.data.at[code, "DisplayName"] = self.get_display_name()
+        # Cache for safe debugging
+        self._repr_str = self._gen_repr_str()
+
+    def _gen_repr_str(self):
+        return (
+            f"<{self.__class__.__name__} {self._code} {self.Name} ({self.Level.name})>"
+        )
 
     def get_display_name(self):
         if self.Level == Level.subdivision:
             return f"{self.Name}, {self.CountryCode}"
         if self.Level == Level.gleam_basin:
-            return f"{self.Name}, {self.SubdivisionCode}"
+            if pd.notnull(self.SubdivisionCode) and self.SubdivisionCode != "":
+                return f"{self.Name}, {self.SubdivisionCode}"
+            else:
+                return f"{self.Name}, {self.CountryCode}"
         return self.Name
 
     def __getattr__(self, name):
@@ -74,7 +84,7 @@ class Region:
         return self._rds().data.at[self._code, name]
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} {self._code} {self.Name} ({self.Level})>"
+        return self._repr_str
 
     def __setattr__(self, name, val):
         """Forbid direct writes to anything but _variables."""

--- a/epimodel/utils.py
+++ b/epimodel/utils.py
@@ -56,7 +56,7 @@ def read_csv_smart(
     skip_unknown: bool = False,
     levels=None,
     drop_underscored: bool = True,
-    skip=(),
+    prefer_higher=False,
     **kwargs,
 ) -> pd.DataFrame:
     """
@@ -64,8 +64,9 @@ def read_csv_smart(
     perform basic checks.
 
     For every row, the named region is found in the region dataset by name or code.
-    Name matches must be unique within selected levels
-    (see `RegionDataset.find_one_by_name`) and Codes.
+    Without `prefer_higher`, name matches must be unique within selected levels (see
+    `RegionDataset.find_one_by_name`). With `prefer_higher` the highest level is
+    preferred (but still must be unique).
 
     If not given, the name/code column is auto-detected from "Code", "code", "Name",
     "name". The date column names tried are "Date", "date", "Day", "day".
@@ -83,6 +84,9 @@ def read_csv_smart(
         rs = set(rds.find_all_by_name(n, levels=levels))
         if n in rds:
             rs.add(rds[n])
+        if prefer_higher:
+            max_level = max(r.Level for r in rs)
+            rs = set(r for r in rs if r.Level == max_level)
         if len(rs) > 1:
             raise Exception(f"Found multiple matches for {n!r}: {rs!r}")
         elif len(rs) == 1:


### PR DESCRIPTION
General
* `read_csv_smart` optionally prefers larger regions
* Fixed broken pandas Region display
* Fix DisplayName (contained "nan" for some basins)
Update gleam import
* Add overwrite option
* Make work for gleam basins (cities)
* Ignore missing initial_compartments
Update web export
* Mathij's many updates from #44 (cherry-picked)
* Ignore cities missing M49
* Ignore empty TZ list