### PR TITLE
Cleanup WebExport

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,6 @@ web_export:
   rates: rates.csv
   timezones: timezones.csv
   un_age_dist: various/age_dist_un.csv
-  traces_v3: various/traces_v3.csv
 
 ### Generating GLEAM scenarios
 # All combinations of groups and scenarios are created,

--- a/epimodel/exports/epidemics_org.py
+++ b/epimodel/exports/epidemics_org.py
@@ -6,7 +6,7 @@ import socket
 import subprocess
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Iterable
 
 import numpy as np
 import pandas as pd
@@ -31,7 +31,7 @@ class WebExport:
         self.created_by = f"{getpass.getuser()}@{socket.gethostname()}"
         self.comment = comment
         self.date_resample = date_resample
-        self.export_regions = {}
+        self.export_regions: Dict[str, WebExportRegion] = {}
 
     def to_json(self):
         return {
@@ -176,7 +176,7 @@ class WebExportRegion:
     @staticmethod
     def get_stats(
         cummulative_active_df: pd.DataFrame, simulation_specs: pd.DataFrame
-    ) -> Dict[str, float]:
+    ) -> Dict[str, Dict[str, float]]:
         stats = {}
         for group in simulation_specs.Group.unique():
             sim_ids = list(simulation_specs[simulation_specs.Group == group].index)
@@ -185,7 +185,7 @@ class WebExportRegion:
         return stats
 
     @staticmethod
-    def get_date_index(models: pd.DataFrame) -> None:
+    def get_date_index(models: pd.DataFrame) -> Iterable[datetime.datetime]:
         date_indexes = models.groupby(level=0).apply(
             lambda x: x.index.get_level_values("Date")
         )
@@ -200,7 +200,7 @@ class WebExportRegion:
     def extract_external_data(
         models: pd.DataFrame, simulation_spec: pd.DataFrame, groups,
     ) -> Dict[str, Any]:
-        d = {
+        d: Dict[str, Any] = {
             "date_index": [
                 x.isoformat() for x in WebExportRegion.get_date_index(models)
             ]

--- a/epimodel/exports/epidemics_org.py
+++ b/epimodel/exports/epidemics_org.py
@@ -491,7 +491,6 @@ def process_export(args) -> None:
     for code in export_regions:
         reg: Region = args.rds[code]
         m49 = int(reg["M49Code"]) if pd.notnull(reg["M49Code"]) else -1
-        iso3 = reg["CountryCodeISOa3"]
 
         ex.new_region(
             reg,

--- a/epimodel/exports/epidemics_org.py
+++ b/epimodel/exports/epidemics_org.py
@@ -202,7 +202,7 @@ class WebExportRegion:
     ) -> Dict[str, Any]:
         d: Dict[str, Any] = {
             "date_index": [
-                x.isoformat() for x in WebExportRegion.get_date_index(models)
+                x.date().isoformat() for x in WebExportRegion.get_date_index(models)
             ]
         }
         traces = []

--- a/epimodel/exports/epidemics_org.py
+++ b/epimodel/exports/epidemics_org.py
@@ -155,7 +155,7 @@ class WebExportRegion:
                 )
             d["JohnsHopkins"] = {
                 "Date": [x.date().isoformat() for x in hopkins.index],
-                **hopkins.replace({np.nan: None}).to_dict(orient="list"),
+                **hopkins.astype("Int64").replace({pd.NA: None}).to_dict(orient="list"),
             }
 
         if foretold is not None:
@@ -235,7 +235,6 @@ class WebExportRegion:
             "CurrentEstimate": self.current_estimate,
         }
         for n in [
-            "Population",
             "Lat",
             "Lon",
             "OfficialName",
@@ -249,6 +248,9 @@ class WebExportRegion:
         ]:
             if not pd.isnull(self.region[n]):
                 d[n] = self.region[n]
+
+        if not pd.isnull(self.region["Population"]):
+            d["Population"] = int(self.region["Population"])
 
         if self.current_estimate is not None:
             d["CurrentEstimate"] = self.current_estimate.to_dict()

--- a/epimodel/exports/epidemics_org.py
+++ b/epimodel/exports/epidemics_org.py
@@ -445,8 +445,6 @@ def process_export(args) -> None:
 
     batch = Batch.open(args.BATCH_FILE)
     simulation_specs: pd.DataFrame = batch.hdf["simulations"]
-    # TODO: models_df_old likely not needed anymore
-    models_df_old: pd.DataFrame = batch.hdf["new_fraction"]
     cummulative_active_df = batch.get_cummulative_active_df()
 
     estimates_df = epimodel.read_csv_smart(args.estimates, args.rds, prefer_higher=True)
@@ -481,8 +479,7 @@ def process_export(args) -> None:
     analyze_data_consistency(
         args.debug,
         export_regions,
-        # TODO: replace by cummulative version as models are not needed anymore
-        models_df_old,
+        cummulative_active_df,
         rates_df,
         hopkins_df,
         foretold_df,


### PR DESCRIPTION
- Remove V3 traces, fixes https://github.com/epidemics/covid/issues/442
- In data verification `models_df -> cummulative_active_df`, fixes https://github.com/epidemics/covid/issues/410
- Remove time part for traces
- Replace floats for ints in exported json for population and JH data (verified to work)
- Add typings