### PR TITLE
Pipeline fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This by default uses data in `data/inputs` and exports data to `data/outputs/exa
     --export-name test-export \
     --UpdateForetold-foretold-output data-dir/inputs/fixtures/foretold.csv \
     --ExtractSimulationsResults-models-file data-dir/inputs/fixtures/gleam-models.hdf5 \
-    --ExtractSimulationsResults-single-result this-is-now-ignored
+    --ExtractSimulationsResults-simulation-directory this-is-now-ignored
 ```
 
 After the pipeline finishes, you should see the results in `data-dir/outputs/example/`
@@ -74,7 +74,7 @@ You provide all file inputs, foretold_channel and parameters, tweak configs to y
     ```
     ./luigi WebExport \
     --export-name my-export \
-    --ExtractSimulationsResults-single-result ~/GLEAMviz/data/simulations/82131231323.ghv5/results.h5
+    --ExtractSimulationsResults-simulation-directory ~/GLEAMviz/data/simulations/ 
     ```
 
 4. upload the result data using `./luigi WebUpload --export-data data-dir/outputs/web-exports/my-export` task

--- a/epimodel/exports/epidemics_org.py
+++ b/epimodel/exports/epidemics_org.py
@@ -323,8 +323,7 @@ def upload_export(dir_to_export: Path, gs_prefix: str, channel: str):
             log.error(f"Error in JSON file {json_file}")
             raise
 
-    release_name = dir_to_export.parts[-1]
-    gcs_path = os.path.join(gs_prefix, channel, release_name)
+    gcs_path = os.path.join(gs_prefix, channel)
     log.info(f"Uploading data folder {dir_to_export} to {gcs_path} ...")
     cmd = CMD + ["-Z", "-R", dir_to_export.as_posix(), gcs_path]
     log.debug(f"Running {cmd!r}")

--- a/epimodel/tasks.py
+++ b/epimodel/tasks.py
@@ -305,17 +305,26 @@ class ExportSimulationDefinitions(luigi.Task):
         self.stamp_file_path.touch()
 
 
+class GleamvizResultsTarget(luigi.Target):
+    def __init__(self, path):
+        self.path = path
+
+    def exists(self):
+        for _, _, files in os.walk(self.path, topdown=False):
+            if "results.h5" in files:
+                return True
+        return False
+
+
 class GleamvizResults(luigi.ExternalTask):
     """This is done manually by a user via Gleam software. You should see the new
     simulations loaded. Run all of them and "Retrieve results"
     (do not export manually). Exit gleamviz."""
 
-    single_result = luigi.Parameter(
+    simulation_directory = luigi.Parameter(
         description=(
-            "A path to any one gleamviz simulation directory you downloaded "
-            "via 'retrieve results' in the gleam software. For example, it "
-            "could be something like "
-            "'~/GLEAMviz/data/simulations/82131231323.ghv5'"
+            "A path to the gleamviz simulation directory. For example, it "
+            "could be something like '~/GLEAMviz/data/simulations/'"
         )
     )
 
@@ -323,7 +332,7 @@ class GleamvizResults(luigi.ExternalTask):
         return ExportSimulationDefinitions()
 
     def output(self):
-        return luigi.LocalTarget(Path(self.single_result).expanduser())
+        return GleamvizResultsTarget(Path(self.simulation_directory).expanduser())
 
 
 @inherits(GleamvizResults)
@@ -355,7 +364,7 @@ class ExtractSimulationsResults(luigi.Task):
     def run(self):
         batch_file = self.input()["batch_file"].path
 
-        simulation_directory = os.path.dirname(self.input()["gleamviz_result"].path)
+        simulation_directory = self.input()["gleamviz_result"].path
 
         config_yaml = ConfigYaml.load(self.input()["config_yaml"].path)
         regions_dataset = RegionsDatasetSubroutine.load_rds(self)

--- a/epimodel/tasks.py
+++ b/epimodel/tasks.py
@@ -312,10 +312,10 @@ class GleamvizResults(luigi.ExternalTask):
 
     single_result = luigi.Parameter(
         description=(
-            "A path to any one `results.h5` gleamviz files you downloaded "
+            "A path to any one gleamviz simulation directory you downloaded "
             "via 'retrieve results' in the gleam software. For example, it "
             "could be something like "
-            "'~/GLEAMviz/data/simulations/82131231323.ghv5/results.h5'"
+            "'~/GLEAMviz/data/simulations/82131231323.ghv5'"
         )
     )
 

--- a/tests/example-run.sh
+++ b/tests/example-run.sh
@@ -116,7 +116,7 @@ echo "Now faking the results of ImportGleamBatch in $RESULTS_FAKE"
 echo ""
 touch $RESULTS_FAKE
 echo "CAUTION: The following will fail if you haven't retrieved GLEAMviz results."
-show_and_do_luigi ExtractSimulationsResults --single-result $RESULTS_FAKE
+show_and_do_luigi ExtractSimulationsResults --simulation-directory $SIM_DIR
 user_continue
 
 echo ""
@@ -126,7 +126,7 @@ echo ""
 echo "$LUIGI WebExport --export-name test-output"
 user_continue
 $LUIGI WebExport \
-  --ExtractSimulationsResults-single-result $RESULTS_FAKE  \
+  --ExtractSimulationsResults-simulation-directory $SIM_DIR  \
   --ExtractSimulationsResults-models-file data-dir/inputs/fixtures/gleam-models.hdf5 \
   --export-name test-output \
   --web-export-directory $OUTPUT_DIRECTORY/web-exports


### PR DESCRIPTION
2 issues I ran into when running the pipeline:
1. The gcs_path always ends with the folder name of the web export. This means that if will end with latest, or whatever you named your export. As far as I understand this means you cannot upload to any valid channel url. A valid channel url would be `gs://static-covid/static/v4/main` etc. The original code will always generate an url such as `gs://static-covid/static/v4/main/something`.
2. single_result docstring is misleading, the parameter should point to a directory containing results.h5, and not the actual h5 file. I changed this target to point directly to the simulations directory. This makes is easier to configure with a local luigi config, since it will not change with every simulation run.