### PR TITLE
CO-448 add a overwrite flag to the WebExport task

### DIFF
--- a/epimodel/exports/epidemics_org.py
+++ b/epimodel/exports/epidemics_org.py
@@ -81,12 +81,16 @@ class WebExport:
         main_data_filename: Path,
         latest=None,
         pretty_print=False,
+        overwrite=False
     ):
         indent = None
         if pretty_print:
             indent = 4
 
-        os.makedirs(export_directory, exist_ok=False)
+        try:
+            os.makedirs(export_directory, exist_ok=overwrite)
+        except FileExistsError:
+            raise RuntimeError("The export already exists, overwrite it by specifying the --overwrite flag")
 
         log.info(f"Writing WebExport to {export_directory} ...")
         for region_code, export_region in tqdm(list(self.export_regions.items()), desc="Writing regions"):

--- a/epimodel/tasks.py
+++ b/epimodel/tasks.py
@@ -496,6 +496,7 @@ class WebExport(luigi.Task):
     )
     comment: str = luigi.Parameter(description="Optional comment to the export",)
     resample: str = luigi.Parameter(description="Pandas dataseries resample")
+    overwrite: bool = luigi.BoolParameter(description="Whether to overwrite an already existing export")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -539,6 +540,7 @@ class WebExport(luigi.Task):
             Path(self.main_data_filename),
             latest="latest",
             pretty_print=self.pretty_print,
+            overwrite=self.overwrite
         )
 
 

--- a/luigi.cfg
+++ b/luigi.cfg
@@ -69,6 +69,7 @@ web_export_directory = %(output_directory)s/web-exports
 main_data_filename = data-v4.json
 comment =
 resample = %(timeseries_resample)s
+overwrite = false
 
 [WebUpload]
 gs_prefix = gs://static-covid/static/v4


### PR DESCRIPTION
Closes https://github.com/epidemics/covid/issues/448

I think that originally the issue talked about problems with the `ExtractSimulationsResults`, however this task no longer produces more than one file, so the task is atomic. In the case it fails it should be trivial to rerun it. The WebExport task does produce multiple files, and if it fails mid way it cannot simply be rerun. In order to alleviate this I added a `--overwrite` flag that you can specify to overwrite the existing web export.